### PR TITLE
Switching the quantum chemistry backend to pyscf

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         os:
           - ubuntu-latest
           - macOS-latest
-          - windows-latest
+          # - windows-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          # - '1.6'
           - '1'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+          # - macOS-latest
+          # - windows-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          # - '1.6'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest
-          # - macOS-latest
-          # - windows-latest
+          - macOS-latest
+          - windows-latest
         arch:
           - x64
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.jl.mem
 *.o
 *.swp
+.CondaPkg
 .DS_Store
 .benchmarkci
 .tmp

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,0 +1,2 @@
+[deps]
+pyscf = ""

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,2 +1,3 @@
-[deps]
+
+[pip.deps]
 pyscf = ""

--- a/Project.toml
+++ b/Project.toml
@@ -5,15 +5,13 @@ version = "0.0.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
-Fermi = "9237668d-08c8-4784-b8dd-383aa52fcf74"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
-Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
 Combinatorics = "1.0.2"
-Fermi = "0.4"
 ITensors = "0.3.15"
-Suppressor = "0.2"
+PythonCall = "0.9.12"
 julia = "1.6"
 
 [extras]

--- a/examples/dissociation.jl
+++ b/examples/dissociation.jl
@@ -20,7 +20,7 @@ function energy_at_bond(r)
   molecule = Molecule([("H", 0.0, 0.0, 0.0), ("H", r, 0.0, 0.0)])
 
   # build electronic hamiltonian and solve HF
-  hf = molecular_orbital_hamiltonian(molecule; basis="sto-3g", diis=false, oda=false)
+  hf = molecular_orbital_hamiltonian(molecule; basis="sto-3g")
   hamiltonian = hf.hamiltonian
   hartree_fock_state = hf.hartree_fock_state
   hartree_fock_energy = hf.hartree_fock_energy

--- a/src/ITensorChemistry.jl
+++ b/src/ITensorChemistry.jl
@@ -16,6 +16,7 @@ include("qubitmaps.jl")
 const pyscf = PythonCall.pynew() # Init to NULL
 function __init__()
   PythonCall.pycopy!(pyscf, pyimport("pyscf"))
+  return nothing
 end
 
 export Atom, Molecule, molecular_orbital_hamiltonian, jordanwigner

--- a/src/ITensorChemistry.jl
+++ b/src/ITensorChemistry.jl
@@ -3,6 +3,7 @@ module ITensorChemistry
 using Fermi
 using ITensors
 using Suppressor
+using PythonCall
 
 import Combinatorics: levicivita
 
@@ -13,6 +14,11 @@ include("molecules.jl")
 include("molecular_orbital_hamiltonian.jl")
 include("pauli.jl")
 include("qubitmaps.jl")
+
+const pyscf = PythonCall.pynew() # Init to NULL
+function __init__()
+    PythonCall.pycopy!(pyscf, pyimport("pyscf"))
+end
 
 export Atom, Molecule, molecular_orbital_hamiltonian, jordanwigner
 end

--- a/src/ITensorChemistry.jl
+++ b/src/ITensorChemistry.jl
@@ -1,8 +1,6 @@
 module ITensorChemistry
 
-using Fermi
 using ITensors
-using Suppressor
 using PythonCall
 
 import Combinatorics: levicivita
@@ -17,7 +15,7 @@ include("qubitmaps.jl")
 
 const pyscf = PythonCall.pynew() # Init to NULL
 function __init__()
-    PythonCall.pycopy!(pyscf, pyimport("pyscf"))
+  PythonCall.pycopy!(pyscf, pyimport("pyscf"))
 end
 
 export Atom, Molecule, molecular_orbital_hamiltonian, jordanwigner

--- a/src/molecular_orbital_hamiltonian.jl
+++ b/src/molecular_orbital_hamiltonian.jl
@@ -1,31 +1,52 @@
 """
-#Source: https://github.com/FermiQC/Fermi.jl/discussions/117
-#
-#Credit to: Gustavo Aroeira (https://github.com/gustavojra)
-#"""
+    molecular_orbital_hamiltonian_coefficients
+    molecule::String 
+    basis="sto-3g"
+    charge=0
+    spin=0
+"""
 function molecular_orbital_hamiltonian_coefficients(
-  molecule; basis="sto-3g", diis=true, oda=true
+  molecule::String; basis="sto-3g", charge=0, spin=0,
 )
-  @suppress begin
-    Fermi.Options.set("molstring", xyz_string(Molecule(molecule)))
-    Fermi.Options.set("basis", basis)
-    Fermi.Options.set("diis", diis)
-    Fermi.Options.set("oda", oda)
+  # Input Check (TODO add UHF)
+  if spin != 0
+    error("ITensorChemistry can only handle spin=0 systems right now!")
   end
-  hf_wfn = @suppress Fermi.HartreeFock.RHF()
-  aoints = @suppress Fermi.Integrals.IntegralHelper(orbitals=hf_wfn.orbitals)
 
-  hα = @suppress aoints["T"] + aoints["V"]
-  gα = @suppress aoints["ERI"]
+  mol = pyscf.gto.M(; atom=molecule, basis=basis, charge=charge, spin=spin, verbose=3)
 
-  # Convert `g` from Chemist convention to Physicist convention
-  gα = 0.5 * permutedims(gα, (3, 2, 1, 4))
+  # Run HF
+  mf = pyscf.scf.RHF(mol)
+  mf.chkfile = ".tmpfile_pyscf_itensor" # Set this bc Python.tempfile can cause problems sometimes
+  mf.kernel()
+  println("RHF Energy (Ha): ", mf.e_tot)
 
-  nαocc = hf_wfn.molecule.Nα
-  hartree_fock_energy = hf_wfn.energy
-  nuclear_energy = aoints.molecule.Vnuc
+  # Create shorthands for 1- and 2-body integrals in MO basis
+  mo = pyconvert(Array, mf.mo_coeff)
+  hcore_ao = pyconvert(Array, mf.get_hcore())
+
+  n = size(mo, 1)
+  one_body = mo' * hcore_ao * mo
+  two_body = reshape(pyconvert(Array, mol.ao2mo(mf.mo_coeff; aosym=1)), n, n, n, n)
+
+  # Collect data from HF calculation to return
+  hα = one_body
+  gα = 0.5 * permutedims(two_body, (3, 2, 1, 4))
+  nαocc = pyconvert(Number, mol.nelec[1])
+  nuclear_energy = pyconvert(Number, mf.energy_nuc())
+  hartree_fock_energy = pyconvert(Number, mf.e_tot)
+  
+  # println(pyconvert(String, mf.chkfile))
+  rm(pyconvert(String, mf.chkfile))
 
   return (; hα, gα, nαocc, hartree_fock_energy, nuclear_energy)
+end
+
+function molecular_orbital_hamiltonian_coefficients(
+  molecule::Molecule; kwargs...
+)
+  molecular_orbital_hamiltonian_coefficients(xyz_string(Molecule(molecule)); kwargs...)
+
 end
 
 function _molecular_orbital_hamiltonian(hα, gα, nuclear_energy; atol=1e-15)

--- a/src/molecular_orbital_hamiltonian.jl
+++ b/src/molecular_orbital_hamiltonian.jl
@@ -6,7 +6,7 @@
     spin=0
 """
 function molecular_orbital_hamiltonian_coefficients(
-  molecule::String; basis="sto-3g", charge=0, spin=0,
+  molecule::String; basis="sto-3g", charge=0, spin=0
 )
   # Input Check (TODO add UHF)
   if spin != 0
@@ -35,18 +35,17 @@ function molecular_orbital_hamiltonian_coefficients(
   nαocc = pyconvert(Number, mol.nelec[1])
   nuclear_energy = pyconvert(Number, mf.energy_nuc())
   hartree_fock_energy = pyconvert(Number, mf.e_tot)
-  
+
   # println(pyconvert(String, mf.chkfile))
   rm(pyconvert(String, mf.chkfile))
 
   return (; hα, gα, nαocc, hartree_fock_energy, nuclear_energy)
 end
 
-function molecular_orbital_hamiltonian_coefficients(
-  molecule::Molecule; kwargs...
-)
-  molecular_orbital_hamiltonian_coefficients(xyz_string(Molecule(molecule)); kwargs...)
-
+function molecular_orbital_hamiltonian_coefficients(molecule::Molecule; kwargs...)
+  return molecular_orbital_hamiltonian_coefficients(
+    xyz_string(Molecule(molecule)); kwargs...
+  )
 end
 
 function _molecular_orbital_hamiltonian(hα, gα, nuclear_energy; atol=1e-15)

--- a/test/molecular_orbital_hamiltonian.jl
+++ b/test/molecular_orbital_hamiltonian.jl
@@ -6,7 +6,7 @@ using Test
   molecule = Molecule("H₂")
   basis = "sto-3g"
 
-  hf = molecular_orbital_hamiltonian(molecule; basis, diis=false, oda=false)
+  hf = molecular_orbital_hamiltonian(molecule; basis)
   hamiltonian = hf.hamiltonian
   hartree_fock_state = hf.hartree_fock_state
   hartree_fock_energy = hf.hartree_fock_energy
@@ -27,7 +27,7 @@ end
 @testset "fermion hamiltonian" begin
   molecule = Molecule("H₂")
   basis = "sto-3g"
-  hf = molecular_orbital_hamiltonian(molecule; basis, diis=false, oda=false)
+  hf = molecular_orbital_hamiltonian(molecule; basis)
   hamiltonian = hf.hamiltonian
   hartree_fock_state = hf.hartree_fock_state
   hartree_fock_energy = hf.hartree_fock_energy
@@ -39,7 +39,7 @@ end
   @test inner(ψe', He, ψe) ≈ hartree_fock_energy
 
   hf = molecular_orbital_hamiltonian(
-    molecule; basis, diis=false, oda=false, sitetype="Fermion"
+    molecule; basis, sitetype="Fermion"
   )
   hamiltonian = hf.hamiltonian
   hartree_fock_state = hf.hartree_fock_state

--- a/test/molecular_orbital_hamiltonian.jl
+++ b/test/molecular_orbital_hamiltonian.jl
@@ -38,9 +38,7 @@ end
 
   @test inner(ψe', He, ψe) ≈ hartree_fock_energy
 
-  hf = molecular_orbital_hamiltonian(
-    molecule; basis, sitetype="Fermion"
-  )
+  hf = molecular_orbital_hamiltonian(molecule; basis, sitetype="Fermion")
   hamiltonian = hf.hamiltonian
   hartree_fock_state = hf.hartree_fock_state
   hartree_fock_energy = hf.hartree_fock_energy

--- a/test/qubitmaps.jl
+++ b/test/qubitmaps.jl
@@ -5,7 +5,7 @@ using Test
 @testset "Jordan Wigner mapping" begin
   molecule = Molecule("H₂")
   basis = "sto-3g"
-  hf = molecular_orbital_hamiltonian(molecule; basis, diis=false, oda=false)
+  hf = molecular_orbital_hamiltonian(molecule; basis)
   hamiltonian = hf.hamiltonian
   hartree_fock_state = hf.hartree_fock_state
   hartree_fock_energy = hf.hartree_fock_energy
@@ -16,9 +16,7 @@ using Test
   @test inner(ψ₀e', He, ψ₀e) ≈ hartree_fock_energy
   electronE = copy(hartree_fock_energy)
 
-  hf = molecular_orbital_hamiltonian(
-    molecule; basis, diis=false, oda=false, sitetype="Fermion"
-  )
+  hf = molecular_orbital_hamiltonian(molecule; basis, sitetype="Fermion")
   hamiltonian = hf.hamiltonian
   hartree_fock_state = hf.hartree_fock_state
   hartree_fock_energy = hf.hartree_fock_energy
@@ -28,9 +26,7 @@ using Test
   ψ₀f = MPS(fermion_hilbert, hartree_fock_state)
   @test inner(ψ₀f', Hf, ψ₀f) ≈ electronE
 
-  hf = molecular_orbital_hamiltonian(
-    molecule; basis, diis=false, oda=false, sitetype="Qubit"
-  )
+  hf = molecular_orbital_hamiltonian(molecule; basis, sitetype="Qubit")
   hamiltonian = hf.hamiltonian
   hartree_fock_state = hf.hartree_fock_state
   hartree_fock_energy = hf.hartree_fock_energy


### PR DESCRIPTION
# General

Adding PySCF as the backend for the package. 

# TODOs

- [x] Update `README.md` with instructions about `PythonCall`
- [x] Remove `PyCall` and `Fermi.jl` references
- [x] Fix keywords for some of the tests that were specific to `Fermi.jl`