### PR TITLE
Append 0.4 to ITensors compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,7 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
 Combinatorics = "1.0.2"
-ITensors = "0.3.58"
+ITensors = "0.3.58, 0.4"
 PythonCall = "0.9.12"
 julia = "1.6"
 


### PR DESCRIPTION
We can pull this when v0.4 of ITensors.jl is registered.
